### PR TITLE
Act on keypress(block = FALSE) on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: keypress
 Title: Wait for a Key Press in a Terminal
-Version: 1.1.1.9000
+Version: 1.1.2
 Author: Gábor Csárdi [aut, cre], Jon Griffiths [aut]
 Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>
 Description: Wait for a single key press at the 'R' prompt.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # develoment version
 
+- Support non-blocking press on Windows (Rterm)
+
+# 1.1.2
+
 - Support RStudio terminal.
 - Better detection of support in Emacs.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,9 @@
 
 # development version
 
-# 1.2.0
-
 - Support non-blocking press on Windows (Rterm)
 
-# 1.1.2
+# 1.2.0
 
 - Support RStudio terminal.
 - Better detection of support in Emacs.

--- a/inst/include/keypress.h
+++ b/inst/include/keypress.h
@@ -6,6 +6,9 @@
 #include <Rinternals.h>
 #include <R_ext/Rdynload.h>
 
+#define BLOCKING           1
+#define NON_BLOCKING       0
+
 #define KEYPRESS_CHAR      0
 
 #define KEYPRESS_ENTER     1

--- a/src/keypress-win.c
+++ b/src/keypress-win.c
@@ -105,7 +105,6 @@ keypress_key_t getWinChar(int block) {
       }
     }
   }
-  return keypress_special(KEYPRESS_CHAR);
 }
 
 keypress_key_t keypress_read(int block) {

--- a/src/keypress-win.c
+++ b/src/keypress-win.c
@@ -55,55 +55,56 @@ keypress_key_t getWinChar(int block) {
 
     switch (rec.Event.KeyEvent.wVirtualKeyCode) {
 
-      case VK_RETURN: return keypress_special(KEYPRESS_ENTER);
-      case VK_BACK:   return keypress_special(KEYPRESS_BACKSPACE);
-      case VK_LEFT:   return keypress_special(KEYPRESS_LEFT);
-      case VK_RIGHT:  return keypress_special(KEYPRESS_RIGHT);
-      case VK_UP:     return keypress_special(KEYPRESS_UP);
-      case VK_DOWN:   return keypress_special(KEYPRESS_DOWN);
-      case VK_INSERT: return keypress_special(KEYPRESS_INSERT);
-      case VK_DELETE: return keypress_special(KEYPRESS_DELETE);
-      case VK_HOME:   return keypress_special(KEYPRESS_HOME);
-      case VK_END:    return keypress_special(KEYPRESS_END);
-      case VK_ESCAPE: return keypress_special(KEYPRESS_ESCAPE);
+    case VK_RETURN: return keypress_special(KEYPRESS_ENTER);
+    case VK_BACK:   return keypress_special(KEYPRESS_BACKSPACE);
+    case VK_LEFT:   return keypress_special(KEYPRESS_LEFT);
+    case VK_RIGHT:  return keypress_special(KEYPRESS_RIGHT);
+    case VK_UP:     return keypress_special(KEYPRESS_UP);
+    case VK_DOWN:   return keypress_special(KEYPRESS_DOWN);
+    case VK_INSERT: return keypress_special(KEYPRESS_INSERT);
+    case VK_DELETE: return keypress_special(KEYPRESS_DELETE);
+    case VK_HOME:   return keypress_special(KEYPRESS_HOME);
+    case VK_END:    return keypress_special(KEYPRESS_END);
+    case VK_ESCAPE: return keypress_special(KEYPRESS_ESCAPE);
 
-      case VK_F1:     return keypress_special(KEYPRESS_F1);
-      case VK_F2:     return keypress_special(KEYPRESS_F2);
-      case VK_F3:     return keypress_special(KEYPRESS_F3);
-      case VK_F4:     return keypress_special(KEYPRESS_F4);
-      case VK_F5:     return keypress_special(KEYPRESS_F5);
-      case VK_F6:     return keypress_special(KEYPRESS_F6);
-      case VK_F7:     return keypress_special(KEYPRESS_F7);
-      case VK_F8:     return keypress_special(KEYPRESS_F8);
-      case VK_F9:     return keypress_special(KEYPRESS_F9);
-      case VK_F10:    return keypress_special(KEYPRESS_F10);
-      case VK_F11:    return keypress_special(KEYPRESS_F11);
-      case VK_F12:    return keypress_special(KEYPRESS_F12);
+    case VK_F1:     return keypress_special(KEYPRESS_F1);
+    case VK_F2:     return keypress_special(KEYPRESS_F2);
+    case VK_F3:     return keypress_special(KEYPRESS_F3);
+    case VK_F4:     return keypress_special(KEYPRESS_F4);
+    case VK_F5:     return keypress_special(KEYPRESS_F5);
+    case VK_F6:     return keypress_special(KEYPRESS_F6);
+    case VK_F7:     return keypress_special(KEYPRESS_F7);
+    case VK_F8:     return keypress_special(KEYPRESS_F8);
+    case VK_F9:     return keypress_special(KEYPRESS_F9);
+    case VK_F10:    return keypress_special(KEYPRESS_F10);
+    case VK_F11:    return keypress_special(KEYPRESS_F11);
+    case VK_F12:    return keypress_special(KEYPRESS_F12);
 
-      default:
+    default:
       if (rec.Event.KeyEvent.dwControlKeyState &
-        (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)) {
-        switch (chr) {
-          case 1: return keypress_special(KEYPRESS_CTRL_A);
-          case 2: return keypress_special(KEYPRESS_CTRL_B);
-          case 3: return keypress_special(KEYPRESS_CTRL_C);
-          case 4: return keypress_special(KEYPRESS_CTRL_D);
-          case 5: return keypress_special(KEYPRESS_CTRL_E);
-          case 6: return keypress_special(KEYPRESS_CTRL_F);
-          case 8: return keypress_special(KEYPRESS_CTRL_H);
-          case 9: return keypress_special(KEYPRESS_TAB);
-          case 11: return keypress_special(KEYPRESS_CTRL_K);
-          case 12: return keypress_special(KEYPRESS_CTRL_L);
-          case 14: return keypress_special(KEYPRESS_CTRL_N);
-          case 16: return keypress_special(KEYPRESS_CTRL_P);
-          case 20: return keypress_special(KEYPRESS_CTRL_T);
-          case 21: return keypress_special(KEYPRESS_CTRL_U);
-          case 22: return keypress_special(KEYPRESS_CTRL_W);
-        }
+	  (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)) {
+	switch (chr) {
+	case 1: return keypress_special(KEYPRESS_CTRL_A);
+	case 2: return keypress_special(KEYPRESS_CTRL_B);
+	case 3: return keypress_special(KEYPRESS_CTRL_C);
+	case 4: return keypress_special(KEYPRESS_CTRL_D);
+	case 5: return keypress_special(KEYPRESS_CTRL_E);
+	case 6: return keypress_special(KEYPRESS_CTRL_F);
+	case 8: return keypress_special(KEYPRESS_CTRL_H);
+	case 9: return keypress_special(KEYPRESS_TAB);
+	case 11: return keypress_special(KEYPRESS_CTRL_K);
+	case 12: return keypress_special(KEYPRESS_CTRL_L);
+	case 14: return keypress_special(KEYPRESS_CTRL_N);
+	case 16: return keypress_special(KEYPRESS_CTRL_P);
+	case 20: return keypress_special(KEYPRESS_CTRL_T);
+	case 21: return keypress_special(KEYPRESS_CTRL_U);
+	case 22: return keypress_special(KEYPRESS_CTRL_W);
+	}
       } else if (buf[0]) {
-  	    return keypress_utf8(buf);
+	return keypress_utf8(buf);
       }
     }
+
   }
 }
 

--- a/src/keypress-win.c
+++ b/src/keypress-win.c
@@ -39,72 +39,71 @@ keypress_key_t getWinChar(int block) {
   int chr;
 
   for (;; Sleep(10)) {
+
+    GetNumberOfConsoleInputEvents(console_in, &count);
+
+    if ((count == 0) && (block == NON_BLOCKING)) {
+      return keypress_special(KEYPRESS_NONE);
+    }
+
     if (! ReadConsoleInputA(console_in, &rec, 1, &count)) {
       R_THROW_SYSTEM_ERROR("Cannot read from console");
     }
-    if (rec.EventType != KEY_EVENT) {
-      if (block == BLOCKING) continue;
-      else break;
-    }
-    if (! rec.Event.KeyEvent.bKeyDown) {
-      if (block == BLOCKING) continue;
-      else break;
-    }
-
+    if (rec.EventType != KEY_EVENT) continue;
+    if (! rec.Event.KeyEvent.bKeyDown) continue;
     buf[0] = chr = rec.Event.KeyEvent.uChar.AsciiChar;
 
     switch (rec.Event.KeyEvent.wVirtualKeyCode) {
 
-    case VK_RETURN: return keypress_special(KEYPRESS_ENTER);
-    case VK_BACK:   return keypress_special(KEYPRESS_BACKSPACE);
-    case VK_LEFT:   return keypress_special(KEYPRESS_LEFT);
-    case VK_RIGHT:  return keypress_special(KEYPRESS_RIGHT);
-    case VK_UP:     return keypress_special(KEYPRESS_UP);
-    case VK_DOWN:   return keypress_special(KEYPRESS_DOWN);
-    case VK_INSERT: return keypress_special(KEYPRESS_INSERT);
-    case VK_DELETE: return keypress_special(KEYPRESS_DELETE);
-    case VK_HOME:   return keypress_special(KEYPRESS_HOME);
-    case VK_END:    return keypress_special(KEYPRESS_END);
-    case VK_ESCAPE: return keypress_special(KEYPRESS_ESCAPE);
+      case VK_RETURN: return keypress_special(KEYPRESS_ENTER);
+      case VK_BACK:   return keypress_special(KEYPRESS_BACKSPACE);
+      case VK_LEFT:   return keypress_special(KEYPRESS_LEFT);
+      case VK_RIGHT:  return keypress_special(KEYPRESS_RIGHT);
+      case VK_UP:     return keypress_special(KEYPRESS_UP);
+      case VK_DOWN:   return keypress_special(KEYPRESS_DOWN);
+      case VK_INSERT: return keypress_special(KEYPRESS_INSERT);
+      case VK_DELETE: return keypress_special(KEYPRESS_DELETE);
+      case VK_HOME:   return keypress_special(KEYPRESS_HOME);
+      case VK_END:    return keypress_special(KEYPRESS_END);
+      case VK_ESCAPE: return keypress_special(KEYPRESS_ESCAPE);
 
-    case VK_F1:     return keypress_special(KEYPRESS_F1);
-    case VK_F2:     return keypress_special(KEYPRESS_F2);
-    case VK_F3:     return keypress_special(KEYPRESS_F3);
-    case VK_F4:     return keypress_special(KEYPRESS_F4);
-    case VK_F5:     return keypress_special(KEYPRESS_F5);
-    case VK_F6:     return keypress_special(KEYPRESS_F6);
-    case VK_F7:     return keypress_special(KEYPRESS_F7);
-    case VK_F8:     return keypress_special(KEYPRESS_F8);
-    case VK_F9:     return keypress_special(KEYPRESS_F9);
-    case VK_F10:    return keypress_special(KEYPRESS_F10);
-    case VK_F11:    return keypress_special(KEYPRESS_F11);
-    case VK_F12:    return keypress_special(KEYPRESS_F12);
+      case VK_F1:     return keypress_special(KEYPRESS_F1);
+      case VK_F2:     return keypress_special(KEYPRESS_F2);
+      case VK_F3:     return keypress_special(KEYPRESS_F3);
+      case VK_F4:     return keypress_special(KEYPRESS_F4);
+      case VK_F5:     return keypress_special(KEYPRESS_F5);
+      case VK_F6:     return keypress_special(KEYPRESS_F6);
+      case VK_F7:     return keypress_special(KEYPRESS_F7);
+      case VK_F8:     return keypress_special(KEYPRESS_F8);
+      case VK_F9:     return keypress_special(KEYPRESS_F9);
+      case VK_F10:    return keypress_special(KEYPRESS_F10);
+      case VK_F11:    return keypress_special(KEYPRESS_F11);
+      case VK_F12:    return keypress_special(KEYPRESS_F12);
 
-    default:
+      default:
       if (rec.Event.KeyEvent.dwControlKeyState &
-	  (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)) {
-	switch (chr) {
-	case 1: return keypress_special(KEYPRESS_CTRL_A);
-	case 2: return keypress_special(KEYPRESS_CTRL_B);
-	case 3: return keypress_special(KEYPRESS_CTRL_C);
-	case 4: return keypress_special(KEYPRESS_CTRL_D);
-	case 5: return keypress_special(KEYPRESS_CTRL_E);
-	case 6: return keypress_special(KEYPRESS_CTRL_F);
-	case 8: return keypress_special(KEYPRESS_CTRL_H);
-	case 9: return keypress_special(KEYPRESS_TAB);
-	case 11: return keypress_special(KEYPRESS_CTRL_K);
-	case 12: return keypress_special(KEYPRESS_CTRL_L);
-	case 14: return keypress_special(KEYPRESS_CTRL_N);
-	case 16: return keypress_special(KEYPRESS_CTRL_P);
-	case 20: return keypress_special(KEYPRESS_CTRL_T);
-	case 21: return keypress_special(KEYPRESS_CTRL_U);
-	case 22: return keypress_special(KEYPRESS_CTRL_W);
-	}
+        (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)) {
+        switch (chr) {
+          case 1: return keypress_special(KEYPRESS_CTRL_A);
+          case 2: return keypress_special(KEYPRESS_CTRL_B);
+          case 3: return keypress_special(KEYPRESS_CTRL_C);
+          case 4: return keypress_special(KEYPRESS_CTRL_D);
+          case 5: return keypress_special(KEYPRESS_CTRL_E);
+          case 6: return keypress_special(KEYPRESS_CTRL_F);
+          case 8: return keypress_special(KEYPRESS_CTRL_H);
+          case 9: return keypress_special(KEYPRESS_TAB);
+          case 11: return keypress_special(KEYPRESS_CTRL_K);
+          case 12: return keypress_special(KEYPRESS_CTRL_L);
+          case 14: return keypress_special(KEYPRESS_CTRL_N);
+          case 16: return keypress_special(KEYPRESS_CTRL_P);
+          case 20: return keypress_special(KEYPRESS_CTRL_T);
+          case 21: return keypress_special(KEYPRESS_CTRL_U);
+          case 22: return keypress_special(KEYPRESS_CTRL_W);
+        }
       } else if (buf[0]) {
-	return keypress_utf8(buf);
+  	    return keypress_utf8(buf);
       }
     }
-    if (block == NON_BLOCKING) break;
   }
   return keypress_special(KEYPRESS_CHAR);
 }

--- a/src/keypress-win.c
+++ b/src/keypress-win.c
@@ -38,8 +38,7 @@ keypress_key_t getWinChar(int block) {
   char buf[2] = { 0, 0 };
   int chr;
 
-  while(BLOCKING) {
-    Sleep(10);
+  for (;; Sleep(10)) {
     if (! ReadConsoleInputA(console_in, &rec, 1, &count)) {
       R_THROW_SYSTEM_ERROR("Cannot read from console");
     }


### PR DESCRIPTION
Implement use of `(block = FALSE)` on Windows.
See https://github.com/gaborcsardi/keypress/issues/9